### PR TITLE
Cancel threads at the end of execution

### DIFF
--- a/raven_python_lambda/__init__.py
+++ b/raven_python_lambda/__init__.py
@@ -233,7 +233,7 @@ def install_timers(config, context):
         # the error a few miliseconds before the actual timeout happens.
         time_remaining = context.get_remaining_time_in_millis()
         timers.append(Timer(time_remaining / 2, timeout_warning, (config, context)))
-        timers.append(Timer(max(time_remaining - 500, 0), timeout_error, (config)))
+        timers.append(Timer(max(time_remaining - 500, 0), timeout_error, [config]))
 
     if config.get('capture_memory_warnings'):
         # Schedule the memory watch dog interval. Warning will re-schedule itself if necessary.

--- a/raven_python_lambda/__init__.py
+++ b/raven_python_lambda/__init__.py
@@ -153,6 +153,7 @@ class RavenLambdaWrapper(object):
                     raven_context['tags']['cloudwatch_region'] = event['awsRegion']
 
             # rethrow exception to halt lambda execution
+            timers = []
             try:
                 if self.config.get('auto_bread_crumbs'):
                     # first breadcrumb is the invocation of the lambda itself
@@ -173,13 +174,16 @@ class RavenLambdaWrapper(object):
                     self.config['raven_client'].captureBreadcrumb(**breadcrumb)
 
                 # install our timers
-                install_timers(self.config, context)
+                timers = install_timers(self.config, context)
 
                 # invoke the original function
                 return fn(event, context)
             except Exception as e:
                 self.config['raven_client'].captureException()
                 raise e
+            finally:
+                for t in timers:
+                    t.cancel()
 
         return decorated
 
@@ -223,13 +227,19 @@ def memory_warning(config, context):
 
 def install_timers(config, context):
     """Create the timers as specified by the plugin configuration."""
+    timers = []
     if config.get('capture_timeout_warnings'):
         # We schedule the warning at half the maximum execution time and
         # the error a few miliseconds before the actual timeout happens.
         time_remaining = context.get_remaining_time_in_millis()
-        Timer(time_remaining / 2, timeout_warning, (config, context)).start()
-        Timer(max(time_remaining - 500, 0), timeout_error, (config)).start()
+        timers.append(Timer(time_remaining / 2, timeout_warning, (config, context)))
+        timers.append(Timer(max(time_remaining - 500, 0), timeout_error, (config)))
 
     if config.get('capture_memory_warnings'):
         # Schedule the memory watch dog interval. Warning will re-schedule itself if necessary.
-        Timer(500, memory_warning, (config, context)).start()
+        timers.append(Timer(500, memory_warning, (config, context)))
+
+    for t in timers:
+        t.start()
+
+    return timers

--- a/raven_python_lambda/test_decorator.py
+++ b/raven_python_lambda/test_decorator.py
@@ -1,4 +1,9 @@
+import threading
+from time import sleep
+
 import pytest
+
+from raven_python_lambda import RavenLambdaWrapper
 
 
 def test_raven_lambda_wrapper():
@@ -10,3 +15,19 @@ def test_raven_lambda_wrapper():
 
     with pytest.raises(Exception):
         test_func({'myEvent': 'event'}, {'myContext': 'context'})
+
+
+class FakeContext(object):
+    def get_remaining_time_in_millis(self):
+        return 300000
+
+
+def test_only_has_one_running_thread_after_execution_finishes():
+    @RavenLambdaWrapper()
+    def f(event, context):
+        pass
+
+    f({}, FakeContext())
+
+    sleep(0.1)  # A bit iffy. But if we don't wait a bit the threads will not have stopped
+    assert threading.active_count() == 1, 'expected all scheduled threads to have been removed'


### PR DESCRIPTION
Because lambda doesn't actually stop the Python processes proper after each execution the threads would linger around after finishing. After enough invocations of your function it would start failing from:

      error: can't start new thread
       File "raven_python_lambda/__init__.py", line 176, in decorated
         install_timers(self.config, context)
       File "raven_python_lambda/__init__.py", line 231, in install_timers
         Timer(max(time_remaining - 500, 0), timeout_error, (config)).start()
       File "python2.7/threading.py", line 739, in start
         _start_new_thread(self.__bootstrap, ())  

By collecting all the timers and then canceling them at the end of function execution we're no longer seeing this resource constraint.

Also fixed a completely unrelated bug with time_remaining. While writing the test I got an invocation of it and saw that it couldn't run because the `config` object was splatted out to 8 arguments instead of the one config as expected. :)