### PR TITLE
Fix `Timer` usage and add log level configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ during deployment.
 | `SENTRY_CAPTURE_UNHANDLED` | Enable capture unhandled exceptions (defaults to `true`) |
 | `SENTRY_CAPTURE_MEMORY` | Enable monitoring memory usage (defaults to `true`) |
 | `SENTRY_CAPTURE_TIMEOUTS` | Enable monitoring execution timeouts (defaults to `true`) |
+| `SENTRY_LOG_LEVEL` | Capture logs in sentry starting at this level (defaults to logging.WARNING) |
 
 In addition the library checks for the following optional variables and adds
 them as custom tags automatically:
@@ -288,7 +289,7 @@ For this to work, you will need:
     sqs_name - The name of the SQS queue
     ```
     - An example: `https://user:pass@some-sentry-server?sqs_region=us-west-2&sqs_account=111111111111sqs_name=sentry-queue`
-1. The proxying service enabled and running. Please review the documentation on the 
+1. The proxying service enabled and running. Please review the documentation on the
 [raven-sqs-proxy](https://github.com/Netflix-Skunkworks/raven-sqs-proxy) page for details.
 
 ## Thanks

--- a/raven_python_lambda/__init__.py
+++ b/raven_python_lambda/__init__.py
@@ -100,6 +100,7 @@ class RavenLambdaWrapper(object):
             'capture_errors': boolval(os.environ.get('SENTRY_CAPTURE_ERRORS', True)),
             'filter_local': boolval(os.environ.get('SENTRY_FILTER_LOCAL', True)),
             'logging': boolval(os.environ.get('SENTRY_CAPTURE_LOGS', True)),
+            'log_level': os.environ.get('SENTRY_LOG_LEVEL', logging.WARNING),
             'enabled': boolval(os.environ.get('SENTRY_ENABLED', True)),
         }
         self.config.update(config or {})
@@ -110,7 +111,9 @@ class RavenLambdaWrapper(object):
             self.config['raven_client'] = configure_raven_client(self.config)
 
         if self.config['logging']:
-            setup_logging(SentryHandler(self.config['raven_client']))
+            handler = SentryHandler(self.config['raven_client'])
+            handler.setLevel(self.config['log_level'])
+            setup_logging(handler)
 
     def __call__(self, fn):
         """Wraps our function with the necessary raven context."""

--- a/raven_python_lambda/__init__.py
+++ b/raven_python_lambda/__init__.py
@@ -228,7 +228,7 @@ def memory_warning(config, context):
         )
     else:
         # nothing to do check back later
-        Timer(500, memory_warning, (config, context)).start()
+        Timer(.5, memory_warning, (config, context)).start()
 
 
 def install_timers(config, context):
@@ -237,13 +237,13 @@ def install_timers(config, context):
     if config.get('capture_timeout_warnings'):
         # We schedule the warning at half the maximum execution time and
         # the error a few miliseconds before the actual timeout happens.
-        time_remaining = context.get_remaining_time_in_millis()
+        time_remaining = context.get_remaining_time_in_millis() / 1000
         timers.append(Timer(time_remaining / 2, timeout_warning, (config, context)))
-        timers.append(Timer(max(time_remaining - 500, 0), timeout_error, [config]))
+        timers.append(Timer(max(time_remaining - .5, 0), timeout_error, [config]))
 
     if config.get('capture_memory_warnings'):
         # Schedule the memory watch dog interval. Warning will re-schedule itself if necessary.
-        timers.append(Timer(500, memory_warning, (config, context)))
+        timers.append(Timer(.5, memory_warning, (config, context)))
 
     for t in timers:
         t.start()

--- a/raven_python_lambda/__init__.py
+++ b/raven_python_lambda/__init__.py
@@ -100,7 +100,7 @@ class RavenLambdaWrapper(object):
             'capture_errors': boolval(os.environ.get('SENTRY_CAPTURE_ERRORS', True)),
             'filter_local': boolval(os.environ.get('SENTRY_FILTER_LOCAL', True)),
             'logging': boolval(os.environ.get('SENTRY_CAPTURE_LOGS', True)),
-            'log_level': os.environ.get('SENTRY_LOG_LEVEL', logging.WARNING),
+            'log_level': int(os.environ.get('SENTRY_LOG_LEVEL', logging.WARNING)),
             'enabled': boolval(os.environ.get('SENTRY_ENABLED', True)),
         }
         self.config.update(config or {})


### PR DESCRIPTION
# Fix Timer Usage

`Timer` was previously using an argument in milliseconds. This is incorrect in both python [3](https://docs.python.org/3.6/library/threading.html#threading.Timer) and [2](https://docs.python.org/2.7/library/threading.html#threading.Timer).

# Configure Sentry Log Level Capturing

You can set `SENTRY_LOG_LEVEL` to `logging.WARNING` for example if you want sentry to capture all warnings. Right now it defaults to `logging.WARNING` maybe it should default to `logging.ERROR`.

# Other thoughts
Do you guys think .5 seconds is too much for checking memory usage?

Edit: If it only takes 10s of microseconds it seems like pretty minimal overhead.