### PR TITLE
Loosen the required version for Raven

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(os.path.join(ROOT, "raven_python_lambda", "__about__.py")) as f:
 
 
 install_requires = [
-    'raven==6.1.0',
+    'raven>=6.1.0',
     'psutil==5.2.2'
 ]
 


### PR DESCRIPTION
I was trying to use the latest release of Raven on my project but it was conflicting with this requirement, which seems overly precise.

Same for psutil, but it isn't a concern for me at the moment so I'm not touching it. :)

And it would be nice if this was released on Pypi.

Thanks,
Björn