### PR TITLE
Fix broken build and some __init__ refactoring

### DIFF
--- a/raven_python_lambda/tests/test_decorator.py
+++ b/raven_python_lambda/tests/test_decorator.py
@@ -53,16 +53,19 @@ def test_that_sqs_transport_is_used(sqs, sqs_queue):
 
 def test_that_local_environment_is_ignored(monkeypatch):
     keys = ['IS_OFFLINE', 'IS_LOCAL']
+
     for k in keys:
         monkeypatch.setenv(k, 'yes.')
         wrapper = RavenLambdaWrapper()
         assert not wrapper.config['enabled']
-        assert not wrapper.config['raven_client']
         monkeypatch.delenv(k)
 
 
 def test_that_remote_environment_is_not_ignored(monkeypatch):
     keys = ['IS_OFFLINE', 'IS_LOCAL']
+    def f(event, context):
+        pass
+
     for k in keys:
         try:
             monkeypatch.delenv(k)


### PR DESCRIPTION
* Fixed broken is_local functionality.
* Refactored redudant `RavenLambdaWrapper.__init__` code (logs were attached twice)
* Refactored `is_local` check to run in `__init__` instead of configure_raven_client
* added `config['is_local']`