### PR TITLE
Allow configuring log level with strings

### DIFF
--- a/raven_python_lambda/__about__.py
+++ b/raven_python_lambda/__about__.py
@@ -9,7 +9,7 @@ __title__ = "raven-python-lambda"
 __summary__ = ("Decorator for lambda sentry instrumentation.")
 __uri__ = "https://github.com/Netflix-Skunkworks/raven-python-lambda"
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 
 __author__ = "The developers"
 __email__ = "oss@netflix.com"

--- a/raven_python_lambda/__init__.py
+++ b/raven_python_lambda/__init__.py
@@ -30,6 +30,19 @@ def boolval(v):
     return v in ("yes", "true", "t", "1", True, 1)
 
 
+log_levels = {
+    'CRITICAL': logging.CRITICAL,
+    'ERROR': logging.ERROR,
+    'WARNING': logging.WARNING,
+    'INFO': logging.INFO,
+    'DEBUG': logging.DEBUG
+}
+
+
+def extract_log_level_from_environment(k, default):
+    return log_levels.get(os.environ.get(k)) or int(os.environ.get(k, default))
+
+
 def configure_raven_client(config):
     defaults = {
         'include_paths': (
@@ -96,7 +109,7 @@ class RavenLambdaWrapper(object):
             'filter_local': boolval(os.environ.get('SENTRY_FILTER_LOCAL', True)),
             'is_local': os.environ.get('IS_OFFLINE', False) or os.environ.get('IS_LOCAL', False),
             'logging': boolval(os.environ.get('SENTRY_CAPTURE_LOGS', True)),
-            'log_level': int(os.environ.get('SENTRY_LOG_LEVEL', logging.WARNING)),
+            'log_level': extract_log_level_from_environment('SENTRY_LOG_LEVEL', logging.WARNING),
             'enabled': boolval(os.environ.get('SENTRY_ENABLED', True)),
         }
         self.config.update(config or {})
@@ -116,6 +129,7 @@ class RavenLambdaWrapper(object):
             handler = SentryHandler(self.config['raven_client'])
             handler.setLevel(self.config['log_level'])
             setup_logging(handler)
+
 
     def __call__(self, fn):
         """Wraps our function with the necessary raven context."""

--- a/raven_python_lambda/tests/test_config.py
+++ b/raven_python_lambda/tests/test_config.py
@@ -1,0 +1,57 @@
+import os
+import logging
+from raven_python_lambda import RavenLambdaWrapper
+
+
+class FreshEnvironmentVariables:
+    def __init__(self, values={}):
+        self.intended_values = values
+
+    def __enter__(self):
+        self.old_environment_data = os.environ.copy()
+        os.environ.clear()
+        os.environ.update(self.intended_values)
+
+    def __exit__(self, *args):
+        os.environ.update(self.old_environment_data)
+
+
+def test_config_defaults():
+    with FreshEnvironmentVariables():
+        wrapper = RavenLambdaWrapper()
+
+        assert wrapper.config['capture_timeout_warnings'] == True
+        assert wrapper.config['capture_memory_warnings'] == True
+        assert wrapper.config['capture_unhandled_exceptions'] == True
+        assert wrapper.config['auto_bread_crumbs'] == True
+        assert wrapper.config['capture_errors'] == True
+        assert wrapper.config['filter_local'] == True
+        assert wrapper.config['is_local'] == False
+        assert wrapper.config['log_level'] == logging.WARNING
+        assert wrapper.config['enabled'] == True
+
+        raven_client = wrapper.config['raven_client']
+        assert raven_client.include_paths == set()
+        assert raven_client.ignore_exceptions == set()
+        assert raven_client.release == None
+        assert raven_client.environment == None
+
+        client_tags = raven_client.tags
+        assert client_tags['lambda'] == None
+        assert client_tags['version'] == None
+        assert client_tags['memory_size'] == None
+        assert client_tags['log_group'] == None
+        assert client_tags['log_stream'] == None
+        assert client_tags['service_name'] == None
+        assert client_tags['stage'] == None
+        assert client_tags['alias'] == None
+        assert client_tags['region'] == None
+
+
+def test_log_level_config():
+    with FreshEnvironmentVariables({'SENTRY_LOG_LEVEL': 'ERROR'}):
+        wrapper = RavenLambdaWrapper()
+        assert wrapper.config['log_level'] == logging.ERROR
+    with FreshEnvironmentVariables({'SENTRY_LOG_LEVEL': '50'}):
+        wrapper = RavenLambdaWrapper()
+        assert wrapper.config['log_level'] == logging.CRITICAL

--- a/raven_python_lambda/tests/test_config.py
+++ b/raven_python_lambda/tests/test_config.py
@@ -27,6 +27,7 @@ def test_config_defaults():
         assert wrapper.config['capture_errors'] == True
         assert wrapper.config['filter_local'] == True
         assert wrapper.config['is_local'] == False
+        assert wrapper.config['logging'] == True
         assert wrapper.config['log_level'] == logging.WARNING
         assert wrapper.config['enabled'] == True
 


### PR DESCRIPTION
For example: `SENTRY_LOG_LEVEL=ERROR`, etc.

Per discussion on #21 

I did preserve the existing behavior (e.g. `SENTRY_LOG_LEVEL=40`) to avoid breaking API changes, and I also added some tests around most of the current defaults.