### PR TITLE
User specified memory usage and timeout warning thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ during deployment.
 | `SENTRY_CAPTURE_TIMEOUTS` | Enable monitoring execution timeouts (defaults to `true`) |
 | `SENTRY_CAPTURE_LOGS` | Enable capture log messages (defaults to `true`) |
 | `SENTRY_LOG_LEVEL` | Capture logs in sentry starting at this level (defaults to logging.WARNING) |
+| `SENTRY_TIMEOUT_THRESHOLD` | Set the percent threshold to trigger timeout warning (defaults to 0.50) |
+| `SENTRY_MEMORY_THRESHOLD` | Set the percent threshold to trigger memory usage warning (defaults to 0.75) |
 
 In addition the library checks for the following optional variables and adds
 them as custom tags automatically:

--- a/raven_python_lambda/__about__.py
+++ b/raven_python_lambda/__about__.py
@@ -9,7 +9,7 @@ __title__ = "raven-python-lambda"
 __summary__ = ("Decorator for lambda sentry instrumentation.")
 __uri__ = "https://github.com/Netflix-Skunkworks/raven-python-lambda"
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"
 
 __author__ = "The developers"
 __email__ = "oss@netflix.com"

--- a/raven_python_lambda/__init__.py
+++ b/raven_python_lambda/__init__.py
@@ -102,7 +102,7 @@ class RavenLambdaWrapper(object):
     def __init__(self, config=None):
         self.config = {
             'capture_timeout_warnings': boolval(os.environ.get('SENTRY_CAPTURE_TIMEOUTS', True)),
-            'timeout_warning_threshold': float(os.environ.get('SENTRY_WARNING_THRESHOLD', 0.50)),
+            'timeout_warning_threshold': float(os.environ.get('SENTRY_TIMEOUT_THRESHOLD', 0.50)),
             'capture_memory_warnings': boolval(os.environ.get('SENTRY_CAPTURE_MEMORY', True)),
             'memory_warning_threshold': float(os.environ.get('SENTRY_MEMORY_THRESHOLD', 0.75)),
             'capture_unhandled_exceptions': boolval(os.environ.get('SENTRY_CAPTURE_UNHANDLED', True)),

--- a/raven_python_lambda/__init__.py
+++ b/raven_python_lambda/__init__.py
@@ -102,7 +102,9 @@ class RavenLambdaWrapper(object):
     def __init__(self, config=None):
         self.config = {
             'capture_timeout_warnings': boolval(os.environ.get('SENTRY_CAPTURE_TIMEOUTS', True)),
+            'timeout_warning_threshold': float(os.environ.get('SENTRY_WARNING_THRESHOLD', 0.50)),
             'capture_memory_warnings': boolval(os.environ.get('SENTRY_CAPTURE_MEMORY', True)),
+            'memory_warning_threshold': float(os.environ.get('SENTRY_MEMORY_THRESHOLD', 0.75)),
             'capture_unhandled_exceptions': boolval(os.environ.get('SENTRY_CAPTURE_UNHANDLED', True)),
             'auto_bread_crumbs': boolval(os.environ.get('SENTRY_AUTO_BREADCRUMBS', True)),
             'capture_errors': boolval(os.environ.get('SENTRY_CAPTURE_ERRORS', True)),
@@ -236,7 +238,9 @@ def memory_warning(config, context):
     limit = float(context.memory_limit_in_mb)
     p = used / limit
 
-    if p >= 0.75:
+    memory_threshold = config.get('memory_warning_threshold')
+
+    if p >= memory_threshold:
         config['raven_client'].captureMessage(
             'Memory Usage Warning',
             level='warning',
@@ -254,10 +258,12 @@ def install_timers(config, context):
     """Create the timers as specified by the plugin configuration."""
     timers = []
     if config.get('capture_timeout_warnings'):
-        # We schedule the warning at half the maximum execution time and
-        # the error a few miliseconds before the actual timeout happens.
+        timeout_threshold = config.get('timeout_warning_threshold')
+        # Schedule the warning at the user specified threshold given in percent.
+        # ie: 0.50 of 30000 ms = 15000ms
+        # Schedule the error a few milliseconds before the actual timeout happens.
         time_remaining = context.get_remaining_time_in_millis() / 1000
-        timers.append(Timer(time_remaining / 2, timeout_warning, (config, context)))
+        timers.append(Timer(time_remaining * timeout_threshold, timeout_warning, (config, context)))
         timers.append(Timer(max(time_remaining - .5, 0), timeout_error, [config]))
 
     if config.get('capture_memory_warnings'):

--- a/raven_python_lambda/tests/test_config.py
+++ b/raven_python_lambda/tests/test_config.py
@@ -21,7 +21,9 @@ def test_config_defaults():
         wrapper = RavenLambdaWrapper()
 
         assert wrapper.config['capture_timeout_warnings'] == True
+        assert wrapper.config['timeout_warning_threshold'] == 0.50
         assert wrapper.config['capture_memory_warnings'] == True
+        assert wrapper.config['memory_warning_threshold'] == 0.75
         assert wrapper.config['capture_unhandled_exceptions'] == True
         assert wrapper.config['auto_bread_crumbs'] == True
         assert wrapper.config['capture_errors'] == True


### PR DESCRIPTION
Added two config options to allow for configuring the thresholds to trigger the timeout and memory usage events. The default values fallback to the current hard-coded ones if these options aren't specified.

config options:
`timeout_warning_threshold` (environment variable: `SENTRY_TIMEOUT_THRESHOLD`)
`memory_warning_threshold` (environment variable: `SENTRY_MEMORY_THRESHOLD`)

These are float values that represent the percentage for the threshold trigger.

For example: To have a timeout warning at 30 seconds on a function with a max runtime of 60 seconds, set `timeout_warning_threshold = 0.50`

