### PR TITLE
Remove unnecessary if statement

### DIFF
--- a/raven_python_lambda/__about__.py
+++ b/raven_python_lambda/__about__.py
@@ -9,7 +9,7 @@ __title__ = "raven-python-lambda"
 __summary__ = ("Decorator for lambda sentry instrumentation.")
 __uri__ = "https://github.com/Netflix-Skunkworks/raven-python-lambda"
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 
 __author__ = "The developers"
 __email__ = "oss@netflix.com"

--- a/raven_python_lambda/__init__.py
+++ b/raven_python_lambda/__init__.py
@@ -163,8 +163,7 @@ class RavenLambdaWrapper(object):
                          'user_agent': identity.get('userAgent')
                      }
 
-            # Add additional tags for AWS_PROXY endpoints
-            if event.get('requestContext'):
+                # Add additional tags for AWS_PROXY endpoints
                 raven_context['tags'] = {
                     'api_id': event['requestContext']['apiId'],
                     'api_stage': event['requestContext']['stage'],

--- a/raven_python_lambda/__init__.py
+++ b/raven_python_lambda/__init__.py
@@ -132,7 +132,6 @@ class RavenLambdaWrapper(object):
             handler.setLevel(self.config['log_level'])
             setup_logging(handler)
 
-
     def __call__(self, fn):
         """Wraps our function with the necessary raven context."""
         @functools.wraps(fn)


### PR DESCRIPTION
This PR removes an unnecessary if statement.

The code was checking twice for `if event.get('requestContext'):`.
Now it only checks one.

PS: I've been using the plugin for my serverless project and it's great! Good job. Also this is my first open source PR