### PR TITLE
Handle situation when “headers” is None.

### DIFF
--- a/raven_python_lambda/__about__.py
+++ b/raven_python_lambda/__about__.py
@@ -9,7 +9,7 @@ __title__ = "raven-python-lambda"
 __summary__ = ("Decorator for lambda sentry instrumentation.")
 __uri__ = "https://github.com/Netflix-Skunkworks/raven-python-lambda"
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"
 
 __author__ = "The developers"
 __email__ = "oss@netflix.com"

--- a/raven_python_lambda/__init__.py
+++ b/raven_python_lambda/__init__.py
@@ -192,7 +192,7 @@ class RavenLambdaWrapper(object):
                     if event.get('requestContext'):
                         breadcrumb['data'] = {
                             'http_method': event['requestContext']['httpMethod'],
-                            'host': event['headers']['Host'],
+                            'host': event.get('headers', {}).get('Host'),
                             'path': event['path']
                         }
 

--- a/raven_python_lambda/__init__.py
+++ b/raven_python_lambda/__init__.py
@@ -192,7 +192,7 @@ class RavenLambdaWrapper(object):
                     if event.get('requestContext'):
                         breadcrumb['data'] = {
                             'http_method': event['requestContext']['httpMethod'],
-                            'host': event.get('headers', {}).get('Host'),
+                            'host': (event['headers'] or {}).get('Host'),
                             'path': event['path']
                         }
 


### PR DESCRIPTION
I have lambda function that runs behind private api gateway.
It looks that for this case `headers` is being set to None.