### PR TITLE
Allow calling Lambda from an Application Load Balancer (ALB)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: python
 
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
+matrix:
+  include:
+    - python: 2.7
+      dist: xenial
+      sudo: true
+    - python: 3.6
+      dist: xenial
+      sudo: true
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 install:
   - pip install tox-travis coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ matrix:
       dist: xenial
       sudo: true
 
+before_install:
+  # Because Travis has some special configuration for boto that interfere
+  #   https://github.com/travis-ci/travis-ci/issues/7940
+  - "sudo rm -f /etc/boto.cfg"
+
 install:
   - pip install tox-travis coveralls
 

--- a/raven_python_lambda/__init__.py
+++ b/raven_python_lambda/__init__.py
@@ -151,7 +151,7 @@ class RavenLambdaWrapper(object):
 
             # Gather identity information from context if possible
             if event.get('requestContext'):
-                identity = event['requestContext']['identity']
+                identity = event['requestContext'].get('identity')
                 if identity:
                     raven_context['user'] = {
                          'id': identity.get('cognitoIdentityId', None),
@@ -163,11 +163,12 @@ class RavenLambdaWrapper(object):
                      }
 
                 # Add additional tags for AWS_PROXY endpoints
-                raven_context['tags'] = {
-                    'api_id': event['requestContext']['apiId'],
-                    'api_stage': event['requestContext']['stage'],
-                    'http_method': event['requestContext']['httpMethod']
-                }
+                if 'apiId' in event['requestContext']:
+                    raven_context['tags'] = {
+                        'api_id': event['requestContext']['apiId'],
+                        'api_stage': event['requestContext']['stage'],
+                        'http_method': event['requestContext']['httpMethod']
+                    }
 
             # Add cloudwatch event context
             if event.get('detail'):
@@ -189,7 +190,7 @@ class RavenLambdaWrapper(object):
                         'data': {}
                     }
 
-                    if event.get('requestContext'):
+                    if event.get('requestContext') and 'httpMethod' in event['requestContext']:
                         breadcrumb['data'] = {
                             'http_method': event['requestContext']['httpMethod'],
                             'host': (event['headers'] or {}).get('Host'),

--- a/raven_python_lambda/tests/test_decorator.py
+++ b/raven_python_lambda/tests/test_decorator.py
@@ -1,6 +1,5 @@
 import threading
 from time import sleep
-import os
 
 import pytest
 
@@ -75,3 +74,17 @@ def test_that_remote_environment_is_not_ignored(monkeypatch):
     wrapper = RavenLambdaWrapper()
     assert wrapper.config['enabled']
     assert wrapper.config['raven_client']
+
+
+def test_doesnt_error_out_if_request_context_is_present_but_not_all_keys():
+    """You can use lambda together with Application Load Balancer (ALB)
+    which uses a different set of keys than previously set. This test
+    covers all the keys that are available when called by an ALB.
+    """
+    event = dict(requestContext=dict(elb=dict(targetGroupArn='arn:aws:something')))
+
+    @RavenLambdaWrapper()
+    def test_func(event, context):
+        return dict(success=True)
+
+    assert test_func(event, FakeContext()) == dict(success=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36
+envlist = py27,py36,py37
 
 [testenv]
 passenv =


### PR DESCRIPTION
You can use lambda together with Application Load Balancer (ALB)
which uses a different set of keys than previously set. This change
makes more checks to ensure that when trying to use more keys
then they exist (or, at least one of the keys exist and we assume
it's a representative sample).

I also went ahead and added py37 support to tox since it's available in Lambda these days.

And with a PR a cute animal picture, this is a culogo or flying lemur! :D 
![colugo - a flying lemur](https://user-images.githubusercontent.com/28559461/56863997-e31dec00-69ef-11e9-9afe-156a046fe2b2.png)